### PR TITLE
Added py-call-osafterfork=true to galaxy config

### DIFF
--- a/roles/galaxy/templates/config/galaxy.yml.j2
+++ b/roles/galaxy/templates/config/galaxy.yml.j2
@@ -68,3 +68,4 @@ galaxy:
   allow_user_dataset_purge: true
   enable_quotas: true
   tool_search_limit: 40
+  py-call-osafterfork: true


### PR DESCRIPTION
Default is now false for python 3.7.x, but we have 3.6.x.  The old default was true.  We can keep that setting, so we must add it to the template and set it to true.