### PR TITLE
Added py-call-osafterfork=true to reports config

### DIFF
--- a/roles/galaxy/templates/config/reports.yml.j2
+++ b/roles/galaxy/templates/config/reports.yml.j2
@@ -24,3 +24,4 @@ reports:
   
   smtp_server: gsmtp.princeton.edu
   error_email_to: biocomp@princeton.edu
+  py-call-osafterfork: true


### PR DESCRIPTION
Default is now false for python 3.7.x, but we have 3.6.x.  The old default was true.  We can keep that setting, so we must add it to the template and set it to true.

This is a separate PR for the reports config